### PR TITLE
Added the functionality to return result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.5
+
+* Breaking change: `addEvent2Cal` now returns `Add2CalendarResult` enum instead of boolean
+* Added support for tracking event addition results (success, canceled, permissionDenied)
+* Note: Android will always return `canceled` due to system limitations
+
 ## 1.0.4
 
 * Update package kotlin version

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your `pubspec.yaml` file within your Flutter Project:
 
 ```yaml
 dependencies:
-  add_2_calendar_new: ^1.0.4
+  add_2_calendar_new: ^1.0.5
 ```
 ### Android integration
 The plugin doesn't need any special permissions by default to add events to the calendar. However, events can also be added without launching the calendar application, for this it is needed to add calendar permissions to your `AndroidManifest.xml`
@@ -63,6 +63,14 @@ Add2Calendar.addEvent2Cal(event);
 ...
 ```
 This will launch the default calendar application to confirm the event and add it to your calendar.
+
+### Return Values
+The plugin now returns an `Add2CalendarResult` enum indicating the outcome:
+- `success` - Event was successfully added
+- `canceled` - User canceled the operation
+- `permissionDenied` - Calendar permission was denied
+
+**Important Note for Android**: Due to Android system limitations, the result will always be `canceled` on Android, even when the event is successfully saved. This is because the Android calendar app doesn't return a proper result to the calling app.
 
 ## Recurring events
 You can add recurrency to your events by specifying a frequency. Optional parameters such as `interval`, `ocurrances` and `endDate` can also be added.

--- a/android/src/main/kotlin/com/javih/add_2_calendar_new/Add2CalendarPlugin.kt
+++ b/android/src/main/kotlin/com/javih/add_2_calendar_new/Add2CalendarPlugin.kt
@@ -1,11 +1,13 @@
-package com.javih.add_2_calendar_new
+package com.javih.add_2_calendar
 
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.provider.CalendarContract
+import android.Manifest
 import androidx.annotation.NonNull
+import androidx.core.content.ContextCompat
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -13,13 +15,14 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 
 
 /** Add2CalendarPlugin  */
-class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegistry.ActivityResultListener {
     /// The MethodChannel that will the communication between Flutter and native Android
     ///
     /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -27,6 +30,8 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private var activity: Activity? = null
     private var context: Context? = null
+
+    private var flutterResult: Result? = null
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         context = flutterPluginBinding.applicationContext
@@ -36,7 +41,8 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         if (call.method == "add2Cal") {
-            val success = insert(
+          flutterResult = result
+          insert(
                 call.argument("title")!!,
                 call.argument("desc") as String?,
                 call.argument("location") as String?,
@@ -47,8 +53,6 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 call.argument("recurrence") as HashMap<String, Any>?,
                 call.argument("invites") as String?
             )
-            result.success(success)
-
         } else {
             result.notImplemented()
         }
@@ -60,6 +64,7 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
+        binding.addActivityResultListener(this)
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
@@ -84,11 +89,10 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         allDay: Boolean,
         recurrence: HashMap<String, Any>?,
         invites: String?
-    ): Boolean {
+    ) {
 
         val mContext: Context = if (activity != null) activity!!.applicationContext else context!!
         val intent = Intent(Intent.ACTION_INSERT)
-
 
         intent.data = CalendarContract.Events.CONTENT_URI
         intent.putExtra(CalendarContract.Events.TITLE, title)
@@ -117,10 +121,27 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
         if (intent.resolveActivity(mContext.packageManager) != null) {
-            mContext.startActivity(intent)
+            activity!!.startActivityForResult(intent, 0)
+        } else {
+            flutterResult!!.error("NoCalendarApp", "No app found on the device that can handle the calendar intent.", null)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode == 0) {
+            if (resultCode == Activity.RESULT_OK) {
+                flutterResult?.success("success")
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+                flutterResult?.success("canceled")
+            } else {
+                val permission = ContextCompat.checkSelfPermission(activity!!, Manifest.permission.WRITE_CALENDAR)
+                if (permission == PackageManager.PERMISSION_DENIED) {
+                    flutterResult?.success("permissionDenied")
+                }
+            }
             return true
         }
-        return false;
+        return false
     }
 
 

--- a/android/src/main/kotlin/com/javih/add_2_calendar_new/Add2CalendarPlugin.kt
+++ b/android/src/main/kotlin/com/javih/add_2_calendar_new/Add2CalendarPlugin.kt
@@ -1,4 +1,4 @@
-package com.javih.add_2_calendar
+package com.javih.add_2_calendar_new
 
 import android.app.Activity
 import android.content.Context

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,8 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
+  MyApp({super.key});
+
   Event buildEvent({Recurrence? recurrence}) {
     return Event(
       title: 'Test eventeee',
@@ -39,10 +41,11 @@ class MyApp extends StatelessWidget {
             ListTile(
               title: Text('Add normal event'),
               trailing: Icon(Icons.calendar_today),
-              onTap: () {
-                Add2Calendar.addEvent2Cal(
+              onTap: () async{
+                final result = await Add2Calendar.addEvent2Cal(
                   buildEvent(),
                 );
+                debugPrint(result.toString());
               },
             ),
             Divider(),
@@ -50,13 +53,14 @@ class MyApp extends StatelessWidget {
               title: const Text('Add event with recurrence 1'),
               subtitle: const Text("weekly for 3 months"),
               trailing: Icon(Icons.calendar_today),
-              onTap: () {
-                Add2Calendar.addEvent2Cal(buildEvent(
+              onTap: () async {
+                final result = await Add2Calendar.addEvent2Cal(buildEvent(
                   recurrence: Recurrence(
                     frequency: Frequency.weekly,
                     endDate: DateTime.now().add(Duration(days: 60)),
                   ),
                 ));
+                debugPrint(result.toString());
               },
             ),
             Divider(),
@@ -64,14 +68,15 @@ class MyApp extends StatelessWidget {
               title: const Text('Add event with recurrence 2'),
               subtitle: const Text("every 2 months for 6 times (1 year)"),
               trailing: Icon(Icons.calendar_today),
-              onTap: () {
-                Add2Calendar.addEvent2Cal(buildEvent(
+              onTap: () async {
+                final result = await Add2Calendar.addEvent2Cal(buildEvent(
                   recurrence: Recurrence(
                     frequency: Frequency.monthly,
                     interval: 2,
                     ocurrences: 6,
                   ),
                 ));
+                debugPrint(result.toString());
               },
             ),
             Divider(),
@@ -79,13 +84,14 @@ class MyApp extends StatelessWidget {
               title: const Text('Add event with recurrence 3'),
               subtitle: const Text("RRULE (android only) every year for 10 years"),
               trailing: Icon(Icons.calendar_today),
-              onTap: () {
-                Add2Calendar.addEvent2Cal(buildEvent(
+              onTap: () async {
+                final result = await Add2Calendar.addEvent2Cal(buildEvent(
                   recurrence: Recurrence(
                     frequency: Frequency.yearly,
                     rRule: 'FREQ=YEARLY;COUNT=10;WKST=SU',
                   ),
                 ));
+                debugPrint(result.toString());
               },
             ),
             Divider(),

--- a/ios/Classes/SwiftAdd2CalendarPlugin.swift
+++ b/ios/Classes/SwiftAdd2CalendarPlugin.swift
@@ -23,21 +23,12 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
       if call.method == "add2Cal" {
         let args = call.arguments as! [String:Any]
-       
-          
-        addEventToCalendar(from: args,completion:{ (success) -> Void in
-              if success {
-                  result(true)
-              } else {
-                  result(false)
-              }
-          })
+        
+        addEventToCalendar(from: args, result: result)
       }
     }
 
-    private func addEventToCalendar(from args: [String:Any], completion: ((_ success: Bool) -> Void)? = nil) {
-        
-        
+    private func addEventToCalendar(from args: [String:Any], result: @escaping FlutterResult) {
         let title = args["title"] as! String
         let description = args["desc"] is NSNull ? nil: args["desc"] as! String
         let location = args["location"] is NSNull ? nil: args["location"] as! String
@@ -51,7 +42,7 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
         let eventStore = EKEventStore()
         let event = createEvent(eventStore: eventStore, alarmInterval: alarmInterval, title: title, description: description, location: location, timeZone: timeZone, startDate: startDate, endDate: endDate, allDay: allDay, url: url, args: args)
 
-        presentCalendarModalToAddEvent(event, eventStore: eventStore, completion: completion)
+        presentCalendarModalToAddEvent(event, eventStore: eventStore, result: result)
     }
     
     private func createEvent(eventStore: EKEventStore, alarmInterval: Double?, title: String, description: String?, location: String?, timeZone: TimeZone?, startDate: Date?, endDate: Date?, allDay: Bool, url: String?, args: [String:Any]) -> EKEvent {
@@ -99,49 +90,55 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
     
     // Show event kit ui to add event to calendar
     
-    func presentCalendarModalToAddEvent(_ event: EKEvent, eventStore: EKEventStore, completion: ((_ success: Bool) -> Void)? = nil) {
+    func presentCalendarModalToAddEvent(_ event: EKEvent, eventStore: EKEventStore, result: @escaping FlutterResult) {
         if #available(iOS 17, *) {
             OperationQueue.main.addOperation {
-                self.presentEventCalendarDetailModal(event: event, eventStore: eventStore)
+                self.presentEventCalendarDetailModal(
+                    event: event,
+                    eventStore: eventStore,
+                    result: result
+                )
             }
         } else {
             let authStatus = getAuthorizationStatus()
             switch authStatus {
             case .authorized:
                 OperationQueue.main.addOperation {
-                    self.presentEventCalendarDetailModal(event: event, eventStore: eventStore)
+                    self.presentEventCalendarDetailModal(
+                        event: event,
+                        eventStore: eventStore,
+                        result: result
+                    )
                 }
-                completion?(true)
             case .notDetermined:
-                //Auth is not determined
-                //We should request access to the calendar
+                // Auth is not determined
+                // We should request access to the calendar
                 eventStore.requestAccess(to: .event, completion: { [weak self] (granted, error) in
                     if granted {
                         OperationQueue.main.addOperation {
-                            self?.presentEventCalendarDetailModal(event: event, eventStore: eventStore)
+                            self?.presentEventCalendarDetailModal(event: event, eventStore: eventStore, result: result)
                         }
-                        completion?(true)
                     } else {
                         // Auth denied
-                        completion?(false)
+                        result("permissionDenied")
                     }
                 })
             case .denied, .restricted:
                 // Auth denied or restricted
-                completion?(false)
+                result("permissionDenied")
             default:
-                completion?(false)
+                result("permissionDenied")
             }
         }
     }
     
     // Present edit event calendar modal
     
-    func presentEventCalendarDetailModal(event: EKEvent, eventStore: EKEventStore) {
+    func presentEventCalendarDetailModal(event: EKEvent, eventStore: EKEventStore, result: @escaping FlutterResult) {
         let eventModalVC = EKEventEditViewController()
         eventModalVC.event = event
         eventModalVC.eventStore = eventStore
-        eventModalVC.editViewDelegate = self
+        eventModalVC.editViewDelegate = Add2CalendarEditViewDelegate(result: result)
         
         if #available(iOS 13, *) {
             eventModalVC.modalPresentationStyle = .fullScreen
@@ -156,9 +153,20 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
     }
 }
 
-extension SwiftAdd2CalendarPlugin: EKEventEditViewDelegate {
+class Add2CalendarEditViewDelegate: NSObject, EKEventEditViewDelegate {
+    final var result: FlutterResult
+
+    init(result: @escaping FlutterResult) {
+        self.result = result
+    }
     
     public func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
+        if action == .saved {
+            result("success")
+        } else {
+            result("canceled")
+        }
+
         controller.dismiss(animated: true, completion: {
             UIApplication.shared.statusBarStyle = statusBarStyle
         })

--- a/lib/add_2_calendar_new.dart
+++ b/lib/add_2_calendar_new.dart
@@ -3,3 +3,4 @@ library add_2_calendar_new;
 export 'package:add_2_calendar_new/src/add_2_cal.dart';
 export 'package:add_2_calendar_new/src/model/event.dart';
 export 'package:add_2_calendar_new/src/model/recurrence.dart';
+export 'package:add_2_calendar_new/src/model/result.dart';

--- a/lib/src/add_2_cal.dart
+++ b/lib/src/add_2_cal.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
 import 'package:add_2_calendar_new/src/model/event.dart';
+import 'package:add_2_calendar_new/src/model/result.dart';
 import 'package:flutter/services.dart';
 
 class Add2Calendar {
   static const MethodChannel _channel = const MethodChannel('add_2_calendar_new');
 
   /// Add an Event (object) to user's default calendar.
-  static Future<bool> addEvent2Cal(Event event) async {
-    return _channel.invokeMethod<bool?>('add2Cal', event.toJson()).then((value) => value ?? false);
+  static Future<Add2CalendarResult> addEvent2Cal(Event event) async {
+    return _channel.invokeMethod<String>('add2Cal', event.toJson()).then((value) => Add2CalendarResult.values.byName(value!));
   }
 }

--- a/lib/src/model/result.dart
+++ b/lib/src/model/result.dart
@@ -1,0 +1,5 @@
+enum Add2CalendarResult {
+  success,
+  canceled,
+  permissionDenied,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: add_2_calendar_new
 description: A new version for a really simple Flutter plugin to add events to each platform's default calendar.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/mauricioluz/add_2_calendar
 
 environment:


### PR DESCRIPTION
### Return Values
The plugin now returns an `Add2CalendarResult` enum indicating the outcome:
- `success` - Event was successfully added
- `canceled` - User canceled the operation
- `permissionDenied` - Calendar permission was denied

**Important Note for Android**: Due to Android system limitations, the result will always be `canceled` on Android, even when the event is successfully saved. This is because the Android calendar app doesn't return a proper result to the calling app.